### PR TITLE
fixed issue with pure pip installation on windows

### DIFF
--- a/channelmap_generator/gui/gui.py
+++ b/channelmap_generator/gui/gui.py
@@ -37,7 +37,7 @@ from channelmap_generator import __version__
 from channelmap_generator.constants import PROBE_N, PROBE_TYPE_MAP, SUPPORTED_1shank_PRESETS, SUPPORTED_4shanks_PRESETS, WIRING_FILE_MAP, REF_ELECTRODES
 from channelmap_generator.utils import imro
 from channelmap_generator.types import Electrode
-from .. import backend
+from channelmap_generator import backend
 
 # Paths to assets
 WIRING_MAPS_DIR = Path(__file__).resolve().parent.parent / "wiring_maps"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ include = ["channelmap_generator*"]
 [tool.setuptools.package-data]
 channelmap_generator = [
     "wiring_maps/*.csv",
-    "gui/*.png",
-    "gui/*.svg",
+    "gui/*/*.png",
+    "gui/*/*.svg",
     "example_layouts/*.pdf",
 ]
 


### PR DESCRIPTION
only tested on windows, please double check that it works (the pure pip installation) on mac

relative import error in gui.py and pathing error in pyproject.toml file to the asset files for the gui.