### PR TITLE
feat(anatomy): enter probe pose by insertion point as well as by tip

### DIFF
--- a/docs/gui-guide.md
+++ b/docs/gui-guide.md
@@ -238,8 +238,8 @@ A **locator figure** above the legend shows three orthogonal brain-atlas slices 
 1. Design your channelmap as usual (presets, drag tools, etc.).
 2. Open the **Anatomical overlay** panel on the right side of the GUI.
 3. Choose your **atlas** (e.g. `allen_mouse_25um`; first use will download ~200 MB).
-4. Enter the **tip coordinates** in atlas µm (AP, ML, DV) — the position of the lowest electrode of shank 0.
-5. If your stereotaxic measurements are relative to bregma, tick **Tip relative to bregma** and enter your stereotaxic coordinates instead (see [Bregma-relative mode](#bregma-relative-coordinate-mode) below).
+4. Pick whether you want to enter **Tip** or **Insertion** coordinates (see [Tip vs. insertion-point entry](#tip-vs-insertion-point-entry) below), then type them in atlas µm (AP, ML, DV). Tip coordinates are the position of the lowest electrode of shank 0; insertion coordinates are where the shank crosses the brain surface.
+5. If your stereotaxic measurements are relative to bregma, tick **Coordinates relative to bregma** and enter your stereotaxic coordinates instead (see [Bregma-relative mode](#bregma-relative-coordinate-mode) below).
 6. Adjust **Pitch** and **Yaw** to match the tilt of your stereotaxic arm if the probe is not inserted vertically.
 7. For multi-shank probes, set **Shank orientation** to indicate which direction the shanks run (0° = shanks along the ML axis, 90° = along AP).
 8. Click **Compute anatomical overlay 🧠**. The colored bands, labels, and locator figure appear immediately.
@@ -255,10 +255,52 @@ A **locator figure** above the legend shows three orthogonal brain-atlas slices 
 | **Pitch** | degrees | AP tilt of the probe shaft. `0` = perfectly vertical. Positive values tip the top of the probe forward (toward +AP). Corresponds to the rotation of the stereotaxic arm around the ML axis. |
 | **Yaw** | degrees | ML tilt of the probe shaft. `0` = perfectly vertical. Positive values tip the top of the probe to the right (toward +ML). Corresponds to rotation around the AP axis. |
 | **Shank orientation** | degrees | For multi-shank probes only: rotation of the shank line around the probe's own long axis. `0°` = shanks arrayed along +ML (probe inserted side-on); `90°` = shanks arrayed along +AP (probe inserted front-to-back). Has no effect on single-shank probes. |
+| **Tip / Insertion** | — | Which coordinate triplet you type. The other one is greyed out and follows automatically. |
+| **Entry AP / ML / DV** | µm (atlas) | The insertion point: where the shank crosses the brain surface, in the same frame as the tip coordinates. |
+| **Insertion depth** | µm | Travel **along the shank** from the insertion point down to the **physical shank tip** — what you advance the manipulator by. Editable in both modes; it is what links the two coordinate triplets. |
+| **⤓ Snap to brain surface** | — | Finds where the current trajectory actually enters the brain in the selected atlas. Disabled until the atlas has been downloaded. |
+
+### Tip vs. insertion-point entry
+
+Surgeries are planned from the craniotomy, not from where the tip ends up. The **Tip / Insertion** switch lets you enter whichever you actually know:
+
+- **Tip** — you type the tip coordinates; the entry point is derived by projecting `Insertion depth` back up the shank.
+- **Insertion** — you type the entry point; the tip is derived by projecting `Insertion depth` down the shank.
+
+The greyed-out triplet is always live: it updates as you type, so you can read off the other end of the trajectory at any time without switching modes.
+
+Because depth is measured *along the shank* rather than as a vertical drop, it is exactly how far you advance the manipulator, and it stays correct at any pitch or yaw — including a fully horizontal probe.
+
+:::{note}
+**Two different "tips".** `Insertion depth` is measured to the **physical shank tip**, because that is what a manipulator reading refers to. The **Tip AP/ML/DV** fields, and everything else in PixelMap, refer to the **lowest electrode**, which sits a little above the shank tip on a stretch of inactive silicon:
+
+| Probe | Shank tip → lowest electrode |
+|---|---|
+| Neuropixels 1.0 (incl. NHP) | 209 µm |
+| Neuropixels 2.0, QuadBase | 206 µm |
+
+PixelMap applies this offset automatically from the selected probe part number, so you can enter the manipulator reading directly. One consequence: an insertion depth *smaller* than the tip length means the shank tip has entered the brain but the electrodes have not yet — the overlay will correctly show them still above the surface.
+:::
+
+#### The switch also chooses the pivot
+
+Changing an angle keeps whichever coordinate you are entering fixed:
+
+- In **Tip** mode, adjusting pitch or yaw pivots the probe **around the tip** — useful when the recording target is what matters.
+- In **Insertion** mode, it pivots **around the entry point** — which is what actually happens when you change the arm angle over a fixed craniotomy.
+
+#### Snapping to the brain surface
+
+**⤓ Snap to brain surface** ray-casts the current trajectory through the atlas annotation and finds the first voxel inside the brain. What it writes depends on the mode:
+
+- In **Insertion** mode, the entry point slides onto the surface and the tip follows at the unchanged depth.
+- In **Tip** mode, the tip stays exactly where it is and **Insertion depth** becomes the surface-to-shank-tip distance — i.e. it answers "how far do I need to lower the probe?".
+
+If the trajectory never enters the brain you get a warning and nothing changes. The button needs the atlas volume, so it stays disabled until the atlas has been downloaded (click **Compute anatomical overlay** once to fetch it).
 
 ### Bregma-relative coordinate mode
 
-Tick **Tip relative to bregma** to switch from absolute atlas coordinates to stereotaxic coordinates measured from a skull landmark. When active, the Tip AP/ML/DV fields accept offsets from bregma (or the anterior commissure, for non-rodent atlases) in µm, following the standard neuroscience convention: AP positive = anterior, ML positive = right of midline, DV positive = ventral (deeper).
+Tick **Coordinates relative to bregma** to switch from absolute atlas coordinates to stereotaxic coordinates measured from a skull landmark. When active, both the Tip and Entry AP/ML/DV fields accept offsets from bregma (or the anterior commissure, for non-rodent atlases) in µm, following the standard neuroscience convention: AP positive = anterior, ML positive = right of midline, DV positive = ventral (deeper).
 
 Three additional fields become editable in this mode:
 

--- a/pixelmap/anatomy/__init__.py
+++ b/pixelmap/anatomy/__init__.py
@@ -7,13 +7,24 @@ Atlas data is downloaded on first use by ``brainglobe-atlasapi`` and cached
 on disk in ``~/.brainglobe/``.  Subsequent calls load from the local cache.
 """
 
-from pixelmap.anatomy.atlas import RegionInfo, list_atlases
+from pixelmap.anatomy.atlas import RegionInfo, list_atlases, surface_point_um
 from pixelmap.anatomy.regions import regions_for_positions
-from pixelmap.anatomy.transform import probe_to_atlas
+from pixelmap.anatomy.transform import (
+    insertion_depth_um,
+    insertion_to_tip,
+    probe_axis,
+    probe_to_atlas,
+    tip_to_insertion,
+)
 
 __all__ = [
     "RegionInfo",
+    "insertion_depth_um",
+    "insertion_to_tip",
     "list_atlases",
+    "probe_axis",
     "probe_to_atlas",
     "regions_for_positions",
+    "surface_point_um",
+    "tip_to_insertion",
 ]

--- a/pixelmap/anatomy/atlas.py
+++ b/pixelmap/anatomy/atlas.py
@@ -20,6 +20,8 @@ from brainglobe_atlasapi.list_atlases import (
     get_downloaded_atlases,
 )
 
+from pixelmap.anatomy.transform import probe_axis
+
 _DEFAULT_ATLAS = "allen_mouse_25um"
 
 
@@ -311,6 +313,19 @@ def volume_center_um(name: str = _DEFAULT_ATLAS) -> tuple[float, float, float]:
     return (n_ap * res[0] / 2.0, n_ml * res[2] / 2.0, n_dv * res[1] / 2.0)
 
 
+def _voxel_indices(coords_um: np.ndarray, voxel_size: np.ndarray) -> np.ndarray:
+    """``(N, 3)`` atlas ``(AP, ML, DV)`` µm → integer ``(ap, dv, ml)`` indices.
+
+    The canonical annotation is indexed ``(AP, DV, ML)`` while coordinates are
+    passed around as ``(AP, ML, DV)``, so the last two swap. ``voxel_size`` is
+    already in annotation order ``(AP, DV, ML)`` — see
+    :func:`canonical_annotation`. Kept in one place because getting this
+    transposition wrong is silent for isotropic atlases.
+    """
+    c = np.asarray(coords_um, dtype=float)
+    return np.round(c[:, [0, 2, 1]] / np.asarray(voxel_size, dtype=float)).astype(int)
+
+
 def lookup_regions(
     atlas_name: str,
     atlas_coords_um: np.ndarray,
@@ -335,14 +350,12 @@ def lookup_regions(
         raise ValueError(f"atlas_coords_um must be (N, 3); got {coords.shape}")
 
     # canonical annotation is indexed (AP, DV, ML); convert µm → voxel.
-    ap_idx = np.round(coords[:, 0] / voxel_size[0]).astype(int)
-    dv_idx = np.round(coords[:, 2] / voxel_size[1]).astype(int)
-    ml_idx = np.round(coords[:, 1] / voxel_size[2]).astype(int)
+    idx = _voxel_indices(coords, voxel_size)
 
     shape = annotation.shape
 
     results: list[RegionInfo | None] = []
-    for ap, dv, ml in zip(ap_idx, dv_idx, ml_idx):
+    for ap, dv, ml in idx:
         if not (0 <= ap < shape[0] and 0 <= dv < shape[1] and 0 <= ml < shape[2]):
             results.append(None)
             continue
@@ -352,6 +365,84 @@ def lookup_regions(
             continue
         results.append(_region_info_from_id(atlas, region_id))
     return results
+
+
+def surface_point_um(
+    atlas_name: str,
+    point_atlas: np.ndarray | tuple[float, float, float],
+    *,
+    pitch_deg: float = 0.0,
+    yaw_deg: float = 0.0,
+    step_um: float | None = None,
+) -> tuple[float, float, float] | None:
+    """Where a probe trajectory enters the brain, as ``(AP, ML, DV)`` µm.
+
+    Walks *down* the trajectory that passes through ``point_atlas`` at the
+    given pose and returns the first sample sitting on a labelled voxel —
+    i.e. the point at which the shank crosses the brain surface.
+
+    The result depends only on the *line*, not on which of its points is
+    passed in: calling this with the tip or with the insertion point gives
+    the same answer. That is what lets the GUI's snap button behave
+    identically in tip-entry and insertion-entry mode.
+
+    Args:
+        atlas_name: brainglobe atlas identifier.
+        point_atlas: any ``(AP, ML, DV)`` µm point on the trajectory.
+        pitch_deg: AP tilt — see :mod:`pixelmap.anatomy.transform`.
+        yaw_deg: ML tilt — see :mod:`pixelmap.anatomy.transform`.
+        step_um: march step. Defaults to the finest voxel dimension, so a
+            thin dorsal layer is never stepped over.
+
+    Returns:
+        The entry point, or ``None`` if the trajectory misses the brain
+        entirely (it never crosses a labelled voxel).
+    """
+    annotation, voxel_size = canonical_annotation(atlas_name)
+    axis = probe_axis(pitch_deg, yaw_deg)          # up the shank, (AP, ML, DV)
+    p = np.asarray(point_atlas, dtype=float).reshape(3)
+
+    n_ap, n_dv, n_ml = annotation.shape
+    # Volume extent in coordinate order (AP, ML, DV); note voxel_size is in
+    # annotation order (AP, DV, ML), hence the crossed indices.
+    extent = np.array([n_ap * voxel_size[0],
+                       n_ml * voxel_size[2],
+                       n_dv * voxel_size[1]])
+
+    # Clip the infinite trajectory to the volume's bounding box, rather than
+    # marching a fixed window around `point_atlas`. The insertion point is by
+    # construction at or above the dorsal surface and is routinely *outside*
+    # the volume, so a fixed window is not guaranteed to reach the brain —
+    # and would make the answer depend on which anchor was passed in.
+    t_lo, t_hi = -np.inf, np.inf
+    for i in range(3):
+        if abs(axis[i]) < 1e-12:                   # trajectory parallel to this face
+            if not (0.0 <= p[i] <= extent[i]):
+                return None
+            continue
+        t0, t1 = (0.0 - p[i]) / axis[i], (extent[i] - p[i]) / axis[i]
+        t_lo, t_hi = max(t_lo, min(t0, t1)), min(t_hi, max(t0, t1))
+    if t_hi < t_lo:
+        return None
+
+    step = float(np.min(voxel_size)) if step_um is None else float(step_um)
+    if step <= 0:
+        raise ValueError(f"step_um must be positive; got {step_um!r}")
+
+    # March from the top of the clipped segment downward, so the first hit is
+    # the entry point rather than the exit wound.
+    ts = np.arange(t_hi, t_lo - step, -step)
+    pts = p[None, :] + ts[:, None] * axis[None, :]
+
+    idx = _voxel_indices(pts, voxel_size)
+    in_bounds = ((idx >= 0) & (idx < np.array([n_ap, n_dv, n_ml]))).all(axis=1)
+    labels = np.zeros(len(ts), dtype=annotation.dtype)
+    labels[in_bounds] = annotation[idx[in_bounds, 0], idx[in_bounds, 1], idx[in_bounds, 2]]
+
+    hit = np.flatnonzero(labels > 0)
+    if hit.size == 0:
+        return None
+    return tuple(float(v) for v in pts[hit[0]])
 
 
 @functools.lru_cache(maxsize=4096)

--- a/pixelmap/anatomy/transform.py
+++ b/pixelmap/anatomy/transform.py
@@ -78,6 +78,42 @@ def bregma_to_atlas_um(
     return (b_ap - ap_r, b_ml + ml_b, b_dv + dv_r)
 
 
+def atlas_to_bregma_um(
+    coords_atlas: tuple[float, float, float],
+    *,
+    bregma_um: tuple[float, float, float],
+    dv_squish: float = 1.0,
+    tilt_deg: float = 0.0,
+) -> tuple[float, float, float]:
+    """Exact inverse of :func:`bregma_to_atlas_um`.
+
+    Needed whenever a coordinate computed in the atlas frame has to be shown
+    back to the user in whichever frame they are typing in.
+
+    Args:
+        coords_atlas: ``(AP, ML, DV)`` in canonical atlas µm.
+        bregma_um: bregma position in canonical atlas ``(AP, ML, DV)`` µm.
+        dv_squish: as in :func:`bregma_to_atlas_um`.
+        tilt_deg: as in :func:`bregma_to_atlas_um`.
+
+    Returns:
+        ``(ap, ml, dv)`` µm from bregma, using the same sign conventions as
+        :func:`bregma_to_atlas_um` takes.
+    """
+    a_ap, a_ml, a_dv = (float(c) for c in coords_atlas)
+    b_ap, b_ml, b_dv = (float(c) for c in bregma_um)
+    # Undo the placement, then un-rotate the nose-up tilt.
+    ap_r, dv_r = b_ap - a_ap, a_dv - b_dv
+    theta = np.deg2rad(tilt_deg)
+    cos_t, sin_t = np.cos(theta), np.sin(theta)
+    ap_b = ap_r * cos_t - dv_r * sin_t
+    dv_s = ap_r * sin_t + dv_r * cos_t
+    # Mirror the forward's truthiness guard: dv_squish == 0 passes through
+    # unscaled there, so it must here too or the round trip breaks at 0.
+    dv_b = dv_s * dv_squish if dv_squish else dv_s
+    return (ap_b, a_ml - b_ml, dv_b)
+
+
 def _R_pitch(pitch_rad: float) -> np.ndarray:
     """AP tilt — rotation around world ML axis. ``probe-y`` rotates -DV → +AP."""
     cp, sp = np.cos(pitch_rad), np.sin(pitch_rad)
@@ -96,6 +132,116 @@ def _R_yaw(yaw_rad: float) -> np.ndarray:
         [0.0, cy, -sy],
         [0.0, sy,  cy],
     ])
+
+
+# Probe-local "up the shank" direction before any tilt: a vertical probe's
+# shank runs from the tip toward -DV.
+_PROBE_Y_LOCAL = np.array([0.0, 0.0, -1.0])
+
+
+def _pose_rotation(pitch_deg: float, yaw_deg: float) -> np.ndarray:
+    """World-axis tilt composition: pitch around ML first, then yaw around AP.
+
+    Pitch is applied first so that it stays the literal AP tilt of the
+    stereotax arm regardless of yaw.
+    """
+    return _R_yaw(np.deg2rad(yaw_deg)) @ _R_pitch(np.deg2rad(pitch_deg))
+
+
+def probe_axis(pitch_deg: float = 0.0, yaw_deg: float = 0.0) -> np.ndarray:
+    """Unit vector pointing from the tip *up* the shank, in atlas (AP, ML, DV).
+
+    Equals ``(sin p, sin y·cos p, -cos y·cos p)``. Independent of
+    ``shank_orientation_deg`` — the spin rotates *around* this axis, so it
+    can never change it.
+
+    This is the direction the probe travels along when it is lowered, which
+    makes it the basis for converting between an insertion point and a tip
+    (:func:`insertion_to_tip`, :func:`tip_to_insertion`).
+    """
+    return _pose_rotation(pitch_deg, yaw_deg) @ _PROBE_Y_LOCAL
+
+
+# Depth reference
+# ---------------
+# ``tip_atlas`` everywhere in this module is the *lowest electrode* (the
+# ``yp = 0`` reference), because that is what the electrode geometry is
+# measured from. Insertion depth, however, is naturally read off a
+# manipulator as travel of the *physical shank tip*, which sits
+# ``tip_length_um`` of inactive silicon below the lowest electrode
+# (209 µm on NP 1.0, 206 µm on NP 2.0 — see ``tip_length_um`` in
+# ``PROBE_FEATURES``). The three functions below take that offset so callers
+# can work in manipulator depth; pass ``0.0`` to measure to the lowest
+# electrode instead.
+
+
+def tip_to_insertion(
+    tip_atlas: np.ndarray | tuple[float, float, float],
+    depth_um: float,
+    pitch_deg: float = 0.0,
+    yaw_deg: float = 0.0,
+    tip_length_um: float = 0.0,
+) -> np.ndarray:
+    """Insertion point for a probe whose shank tip is ``depth_um`` deep.
+
+    Args:
+        tip_atlas: atlas ``(AP, ML, DV)`` µm of the *lowest electrode*.
+        depth_um: travel along the shank from the brain surface to the
+            *physical shank tip*.
+        pitch_deg, yaw_deg: pose — see module docstring.
+        tip_length_um: physical-tip-to-lowest-electrode offset. ``0.0``
+            measures ``depth_um`` to the lowest electrode instead.
+
+    Returns:
+        Atlas ``(AP, ML, DV)`` µm where the shank crosses the brain surface.
+    """
+    tip = np.asarray(tip_atlas, dtype=float).reshape(3)
+    reach = float(depth_um) - float(tip_length_um)
+    return tip + reach * probe_axis(pitch_deg, yaw_deg)
+
+
+def insertion_to_tip(
+    insertion_atlas: np.ndarray | tuple[float, float, float],
+    depth_um: float,
+    pitch_deg: float = 0.0,
+    yaw_deg: float = 0.0,
+    tip_length_um: float = 0.0,
+) -> np.ndarray:
+    """Lowest-electrode position for a probe lowered ``depth_um`` into the brain.
+
+    Inverse of :func:`tip_to_insertion`. ``depth_um`` is travel *along the
+    shank* (what the manipulator advances), not a vertical DV drop, so this
+    stays well defined at any pitch/yaw — including ±90°, where a
+    vertical-depth parameterisation would divide by zero.
+
+    A ``depth_um`` smaller than ``tip_length_um`` is meaningful, not an
+    error: the shank tip has entered the brain but the lowest electrode has
+    not yet, so the returned point sits above the surface.
+    """
+    entry = np.asarray(insertion_atlas, dtype=float).reshape(3)
+    reach = float(depth_um) - float(tip_length_um)
+    return entry - reach * probe_axis(pitch_deg, yaw_deg)
+
+
+def insertion_depth_um(
+    tip_atlas: np.ndarray | tuple[float, float, float],
+    insertion_atlas: np.ndarray | tuple[float, float, float],
+    pitch_deg: float = 0.0,
+    yaw_deg: float = 0.0,
+    tip_length_um: float = 0.0,
+) -> float:
+    """Signed along-shank travel from the insertion point to the shank tip.
+
+    Positive when the tip is below the insertion point (the normal case).
+    **Negative** when the whole shank sits above it — i.e. the probe has not
+    reached that point yet — which is why this projects onto the axis rather
+    than taking a norm: a norm would report a healthy positive depth for a
+    probe that never entered the tissue.
+    """
+    tip = np.asarray(tip_atlas, dtype=float).reshape(3)
+    entry = np.asarray(insertion_atlas, dtype=float).reshape(3)
+    reach = float(np.dot(entry - tip, probe_axis(pitch_deg, yaw_deg)))
+    return reach + float(tip_length_um)
 
 
 def probe_to_atlas(
@@ -125,8 +271,6 @@ def probe_to_atlas(
         raise ValueError(f"electrode_xy must be (N, 2); got {electrode_xy.shape}")
     tip = np.asarray(tip_atlas, dtype=float).reshape(3)
 
-    pitch = np.deg2rad(pitch_deg)
-    yaw = np.deg2rad(yaw_deg)
     spin = np.deg2rad(shank_orientation_deg)
 
     # Probe-local axes before any tilt:
@@ -134,14 +278,13 @@ def probe_to_atlas(
     #   probe-x lies along the shank line. Spin rotates it around probe-y, with
     #     0° giving +ML and +90° giving +AP (rotation is in the horizontal
     #     plane of the un-tilted probe).
-    probe_y_local = np.array([0.0, 0.0, -1.0])
     probe_x_local = np.array([np.sin(spin), np.cos(spin), 0.0])
 
     # World-axis tilts (pitch around world ML; yaw around world AP). Order:
     # pitch first, then yaw — this keeps pitch acting purely as AP tilt.
-    R = _R_yaw(yaw) @ _R_pitch(pitch)
+    R = _pose_rotation(pitch_deg, yaw_deg)
     probe_x = R @ probe_x_local
-    probe_y = R @ probe_y_local
+    probe_y = R @ _PROBE_Y_LOCAL  # == probe_axis(pitch_deg, yaw_deg)
 
     displacements = (
         np.outer(electrode_xy[:, 0], probe_x)

--- a/pixelmap/gui/gui.py
+++ b/pixelmap/gui/gui.py
@@ -54,7 +54,13 @@ from pixelmap.utils import imro, survey
 from pixelmap.utils import url_share
 from pixelmap.anatomy import atlas as anatomy_atlas
 from pixelmap.anatomy.schematic import render_locator
-from pixelmap.anatomy.transform import bregma_to_atlas_um
+from pixelmap.anatomy.transform import (
+    atlas_to_bregma_um,
+    bregma_to_atlas_um,
+    insertion_depth_um,
+    insertion_to_tip,
+    tip_to_insertion,
+)
 from pixelmap.anatomy.visualization import compute_region_bands
 
 ## Configure logging
@@ -69,6 +75,17 @@ DEFAULT_PORT = 5007
 
 # Enable Panel extensions
 pn.extension("tabulator", notifications=True)
+
+
+def _fval(widget, default: float = 0.0) -> float:
+    """Read a numeric widget's value, tolerating an empty box.
+
+    ``FloatInput.value`` is None-able and the browser sends ``null`` when the
+    user clears the field, so a bare ``float(w.value)`` raises inside whatever
+    watcher happens to be running.
+    """
+    v = widget.value
+    return default if v is None else float(v)
 
 
 def _darken_hex(hex_color: str, factor: float = 0.6) -> str:
@@ -256,6 +273,13 @@ class ChannelmapGUI(param.Parameterized):
         self.survey_color_bar = None
         self.survey_color_bar_title = None
         self._survey_range_suspend = False
+
+        # Anatomy coordinate-entry state. Both flags gate widget writes made
+        # from code rather than by the user; initialised here so they always
+        # exist, including during create_widgets().
+        self._anatomy_overlay_active = False
+        self._suppress_anatomy_recompute = False
+        self._syncing_coords = False
 
         # Load initial data
         self.load_probe_data()
@@ -1192,9 +1216,9 @@ class ChannelmapGUI(param.Parameterized):
                 shank_positions=probe_xs,
                 y_range=(0.0, y_max),
                 tip_atlas=tip,
-                pitch_deg=float(self.pitch_input.value),
-                yaw_deg=float(self.yaw_input.value),
-                shank_orientation_deg=float(self.shank_orientation_input.value),
+                pitch_deg=_fval(self.pitch_input),
+                yaw_deg=_fval(self.yaw_input),
+                shank_orientation_deg=_fval(self.shank_orientation_input),
                 atlas_name=atlas_name,
                 step_um=25.0,
             )
@@ -1272,23 +1296,23 @@ class ChannelmapGUI(param.Parameterized):
         tilt_deg = 0.0
         if bregma_mode or has_origin:
             bregma_um = (
-                float(self.bregma_ap_input.value),
-                float(self.bregma_ml_input.value),
-                float(self.bregma_dv_input.value),
+                _fval(self.bregma_ap_input),
+                _fval(self.bregma_ml_input),
+                _fval(self.bregma_dv_input),
             )
         if bregma_mode:
-            ap_squish = float(self.ap_squish_input.value) or 1.0
-            ml_squish = float(self.ml_squish_input.value) or 1.0
-            dv_squish = float(self.dv_squish_input.value) or 1.0
-            tilt_deg = float(self.tilt_input.value)
+            ap_squish = _fval(self.ap_squish_input) or 1.0
+            ml_squish = _fval(self.ml_squish_input) or 1.0
+            dv_squish = _fval(self.dv_squish_input) or 1.0
+            tilt_deg = _fval(self.tilt_input)
 
         try:
             _fig = render_locator(
                 atlas_name,
                 tip_atlas=tip,
-                pitch_deg=float(self.pitch_input.value),
-                yaw_deg=float(self.yaw_input.value),
-                shank_orientation_deg=float(self.shank_orientation_input.value),
+                pitch_deg=_fval(self.pitch_input),
+                yaw_deg=_fval(self.yaw_input),
+                shank_orientation_deg=_fval(self.shank_orientation_input),
                 shank_positions=probe_xs,
                 y_range=(0.0, y_max),
                 bregma_um=bregma_um,
@@ -1385,10 +1409,10 @@ class ChannelmapGUI(param.Parameterized):
             )
         return (
             '<div style="font-size: 11px; color: #555; padding: 2px 0 6px 0; text-align: justify;">'
-            "Tip coordinates use a <b>fixed CCF / atlas frame</b>, the same for "
+            "Coordinates use a <b>fixed CCF / atlas frame</b>, the same for "
             "every atlas: (0,0,0) is the <b>anterior-superior-right</b> corner, "
             "with AP increasing posteriorly, DV ventrally and ML from the right. "
-            "Tick the <i>Tip relative to …</i> toggle below to enter coordinates "
+            "Tick the <i>Coordinates relative to …</i> toggle below to enter them "
             "from the atlas's landmark instead (the values below convert them)."
             f"<br>{native_line}"
             "</div>"
@@ -1407,14 +1431,19 @@ class ChannelmapGUI(param.Parameterized):
             self._update_anatomy_origin_note(*events)
             self._update_landmark_labels()
             self.bregma_estimate_header.object = self._bregma_header_html()
+            # The tip was just reseeded (and the landmark may have moved), so
+            # re-derive the insertion point from it regardless of entry mode.
+            self._sync_coord_fields(source="Tip")
         finally:
             self._suppress_anatomy_recompute = False
         # Reflect download state in the button label so users know before clicking.
         name = str(self.atlas_name_input.value).strip()
         if anatomy_atlas.is_downloaded(name):
             self.compute_anatomy_button.name = "Compute anatomical overlay 🧠"
+            self.snap_surface_button.disabled = False
         else:
             self.compute_anatomy_button.name = "Download & compute atlas 🧠 ⏳"
+            self.snap_surface_button.disabled = True
         self._recompute_anatomy_if_active()
 
     def _update_landmark_labels(self):
@@ -1430,7 +1459,7 @@ class ChannelmapGUI(param.Parameterized):
             toggle, prefix = "anterior commissure", "AC"
         else:  # bregma, interaural, …
             toggle, prefix = lm, lm.capitalize()
-        self.bregma_relative_toggle.name = f"Tip relative to {toggle}"
+        self.bregma_relative_toggle.name = f"Coordinates relative to {toggle}"
         self.bregma_ap_input.name = f"{prefix} AP (µm)"
         self.bregma_ml_input.name = f"{prefix} ML (µm)"
         self.bregma_dv_input.name = f"{prefix} DV (µm)"
@@ -1506,27 +1535,204 @@ class ChannelmapGUI(param.Parameterized):
         self.tip_ml_input.value = round(ml, 1)
         self.tip_dv_input.value = round(dv, 1)
 
-    def _tip_atlas_um(self) -> tuple[float, float, float]:
-        """Current tip in canonical atlas (AP, ML, DV) µm, honoring bregma mode."""
-        raw = (
-            float(self.tip_ap_input.value),
-            float(self.tip_ml_input.value),
-            float(self.tip_dv_input.value),
+    def _bregma_origin_um(self) -> tuple[float, float, float]:
+        """The landmark origin the coordinate fields are measured from."""
+        return (
+            _fval(self.bregma_ap_input),
+            _fval(self.bregma_ml_input),
+            _fval(self.bregma_dv_input),
         )
+
+    def _from_display(self, raw: tuple[float, float, float]) -> tuple[float, float, float]:
+        """Typed-in coordinates → canonical atlas (AP, ML, DV) µm.
+
+        Identity in absolute mode; folds in the landmark in bregma mode.
+        DV-squish and tilt are deliberately *not* applied: they warp the
+        atlas image in the locator, they do not relocate the probe in CCF.
+        """
         if not self.bregma_relative_toggle.value:
             return raw
-        # Translation only: DV-squish and tilt are applied as a *visual* warp of
-        # the atlas image in the locator, not by relocating the tip in CCF.
         return bregma_to_atlas_um(
-            raw,
-            bregma_um=(
-                float(self.bregma_ap_input.value),
-                float(self.bregma_ml_input.value),
-                float(self.bregma_dv_input.value),
-            ),
-            dv_squish=1.0,
-            tilt_deg=0.0,
+            raw, bregma_um=self._bregma_origin_um(), dv_squish=1.0, tilt_deg=0.0
         )
+
+    def _to_display(self, atlas: tuple[float, float, float]) -> tuple[float, float, float]:
+        """Canonical atlas (AP, ML, DV) µm → the frame the user is typing in.
+
+        Inverse of :meth:`_from_display`; used to show back a coordinate that
+        was computed in atlas space (a mirrored triplet, a snapped surface
+        point) in whichever frame the coordinate fields are currently in.
+        """
+        if not self.bregma_relative_toggle.value:
+            return tuple(float(c) for c in atlas)
+        return atlas_to_bregma_um(
+            atlas, bregma_um=self._bregma_origin_um(), dv_squish=1.0, tilt_deg=0.0
+        )
+
+    def _tip_atlas_um(self) -> tuple[float, float, float]:
+        """Current tip in canonical atlas (AP, ML, DV) µm, honoring bregma mode.
+
+        The tip fields are kept in sync by :meth:`_sync_coord_fields` whichever
+        entry mode is active, so this stays the single source of the tip for
+        the whole overlay path.
+        """
+        return self._from_display((
+            _fval(self.tip_ap_input),
+            _fval(self.tip_ml_input),
+            _fval(self.tip_dv_input),
+        ))
+
+    ###########################################
+    ##### Tip / insertion coordinate modes ####
+    ###########################################
+
+    def _entry_atlas_um(self) -> tuple[float, float, float]:
+        """Current insertion point in canonical atlas (AP, ML, DV) µm."""
+        return self._from_display((
+            _fval(self.entry_ap_input),
+            _fval(self.entry_ml_input),
+            _fval(self.entry_dv_input),
+        ))
+
+    def _write_triplet(self, widgets, values):
+        """Set three coordinate widgets, rounded for display."""
+        for w, v in zip(widgets, values):
+            w.value = round(float(v), 1)
+
+    def _tip_length_um(self) -> float:
+        """Inactive silicon below the lowest electrode, for the current probe.
+
+        Insertion depth is entered as manipulator travel of the *physical*
+        shank tip, while the electrode geometry is measured from the lowest
+        electrode — this is the offset between the two references.
+        """
+        try:
+            return float(PROBE_FEATURES[self.probe_subtype]["tip_length_um"])
+        except (KeyError, TypeError, ValueError):
+            return 0.0
+
+    def _sync_coord_fields(self, source: str | None = None):
+        """Recompute the *inactive* coordinate triplet from the active one.
+
+        Only ever writes the greyed-out fields, never the ones the user is
+        typing in — so no value the user entered is ever rounded and written
+        back, and the two triplets cannot drift.
+
+        The conversion round-trips through the atlas frame rather than
+        offsetting the displayed numbers directly: in bregma mode the display
+        transform flips the AP axis, so the displayed offset between tip and
+        entry is *not* simply ``depth * probe_axis``.
+        """
+        if source is None:
+            source = self.coord_mode_input.value
+        depth = _fval(self.insertion_depth_input)
+        pitch, yaw = _fval(self.pitch_input), _fval(self.yaw_input)
+        tip_len = self._tip_length_um()
+
+        self._syncing_coords = True
+        try:
+            if source == "Tip":
+                entry = tip_to_insertion(
+                    self._tip_atlas_um(), depth, pitch, yaw, tip_len)
+                self._write_triplet(self._entry_inputs, self._to_display(entry))
+            else:
+                tip = insertion_to_tip(
+                    self._entry_atlas_um(), depth, pitch, yaw, tip_len)
+                self._write_triplet(self._tip_inputs, self._to_display(tip))
+        finally:
+            self._syncing_coords = False
+
+    def _on_pose_input_change(self, event):
+        """Single funnel for every input that moves the probe.
+
+        Mirroring must finish *before* the overlay recomputes, otherwise the
+        first recompute reads a stale tip. Routing these widgets through one
+        handler (instead of also watching them with
+        ``_recompute_anatomy_if_active``) is what guarantees that ordering,
+        and the ``_syncing_coords`` guard stops the mirrored write from
+        re-entering here and rendering the overlay a second time.
+        """
+        if self._syncing_coords:
+            return
+        self._sync_coord_fields()
+        if (self.coord_mode_input.value == "Tip"
+                and event is not None and event.obj is self.insertion_depth_input):
+            # In tip mode the depth only positions the (derived) entry point;
+            # the tip and therefore the overlay are unaffected.
+            return
+        self._recompute_anatomy_if_active()
+
+    def _on_coord_mode_change(self, *events):
+        """Swap which triplet is editable. Deliberately does not recompute.
+
+        Both triplets are already consistent at this moment, so re-deriving
+        one would only re-round it and trigger a pointless overlay render.
+        """
+        tip_active = self.coord_mode_input.value == "Tip"
+        for w in self._tip_inputs:
+            w.disabled = not tip_active
+        for w in self._entry_inputs:
+            w.disabled = tip_active
+
+    def _on_snap_to_surface(self, *events):
+        """Put the insertion point on the brain surface along the current line.
+
+        One geometric operation, applied to whichever quantity the active mode
+        treats as derived: in insertion mode the entry point slides onto the
+        surface (the tip follows at the unchanged depth); in tip mode the tip
+        stays put and the depth becomes the surface-to-tip distance.
+        """
+        name = str(self.atlas_name_input.value).strip()
+        if not anatomy_atlas.is_downloaded(name):
+            self._notify("warning",
+                         f"Download {name} first — click Compute anatomical overlay.")
+            return
+        tip = self._tip_atlas_um()
+        pitch, yaw = _fval(self.pitch_input), _fval(self.yaw_input)
+        try:
+            surface = anatomy_atlas.surface_point_um(
+                name, tip, pitch_deg=pitch, yaw_deg=yaw
+            )
+        except Exception as e:
+            self._notify("error", f"Could not locate the brain surface: {e}")
+            return
+        if surface is None:
+            self._notify("warning",
+                         "This trajectory never enters the brain — check the coordinates.")
+            return
+
+        if self.coord_mode_input.value == "Insertion":
+            # Batch the three writes: each one would otherwise fire its own
+            # watcher and re-render the locator, three times per click.
+            self._suppress_anatomy_recompute = True
+            try:
+                self._write_triplet(self._entry_inputs, self._to_display(surface))
+            finally:
+                self._suppress_anatomy_recompute = False
+            self._recompute_anatomy_if_active()
+        else:
+            depth = insertion_depth_um(
+                tip, surface, pitch, yaw, self._tip_length_um())
+            if depth < 0:
+                self._notify("warning",
+                             "The probe sits entirely above the brain surface — "
+                             "depth set to 0.")
+                depth = 0.0
+            # Clamp before writing: start=0 does not block a programmatic
+            # out-of-range write, and Bokeh would echo a correction back.
+            # The tip has not moved, so no overlay refresh is needed.
+            self.insertion_depth_input.value = round(depth, 1)
+
+    def _notify(self, kind: str, message: str, duration: int = 8000):
+        """Send a Panel notification when one can be shown.
+
+        ``pn.state.notifications`` is None outside a served session (e.g.
+        under pytest), so every call has to be guarded.
+        """
+        if pn.state.notifications is None:
+            print(f"[{kind}] {message}")
+            return
+        getattr(pn.state.notifications, kind)(message, duration=duration)
 
     def _origin_spec(self, name) -> dict:
         """Resolve the recommended coordinate origin + banner status for an atlas.
@@ -1593,13 +1799,25 @@ class ChannelmapGUI(param.Parameterized):
             w.disabled = not on
         self._suppress_anatomy_recompute = True
         try:
-            if on:
+            if on and self.coord_mode_input.value == "Insertion":
+                # Entering from the insertion point: at the landmark, on the
+                # surface, is the meaningful starting guess.
+                self._write_triplet(self._entry_inputs, (0.0, 0.0, 0.0))
+                written = "Insertion"
+            elif on:
                 # Sensible bregma-relative default: at bregma, 4 mm deep.
                 self.tip_ap_input.value = 0.0
                 self.tip_ml_input.value = 0.0
                 self.tip_dv_input.value = 4000.0
+                written = "Tip"
             else:
+                # Reseeds the tip whichever mode is active, so it is the
+                # authoritative triplet here regardless of coord_mode_input.
                 self._update_tip_to_atlas_center()
+                written = "Tip"
+            # The display frame itself just changed, so the other triplet has
+            # to be re-derived from whichever one we actually wrote.
+            self._sync_coord_fields(source=written)
         finally:
             self._suppress_anatomy_recompute = False
         self._recompute_anatomy_if_active()
@@ -2386,6 +2604,39 @@ class ChannelmapGUI(param.Parameterized):
         self.tip_dv_input = pn.widgets.FloatInput(
             name="Tip DV (µm)", value=round(default_dv, 1), step=10.0, sizing_mode="stretch_width", margin=(5, 2)
         )
+        # Coordinates can be entered either as the tip or as the insertion
+        # point (where the shank crosses the brain surface); the inactive
+        # triplet is greyed out and mirrors the other one live.
+        self.coord_mode_input = pn.widgets.RadioButtonGroup(
+            name="Coordinate entry", options=["Tip", "Insertion"], value="Tip",
+            button_type="default", sizing_mode="stretch_width", margin=(8, 2, 2, 2),
+        )
+        # Short labels: three-across in a 370px sidebar leaves ~110px each,
+        # which "Entry AP (µm)" would overflow. Units are stated in the note.
+        self.entry_ap_input = pn.widgets.FloatInput(
+            name="Entry AP", value=round(default_ap, 1), step=10.0,
+            sizing_mode="stretch_width", margin=(5, 2), disabled=True,
+        )
+        self.entry_ml_input = pn.widgets.FloatInput(
+            name="Entry ML", value=round(default_ml, 1), step=10.0,
+            sizing_mode="stretch_width", margin=(5, 2), disabled=True,
+        )
+        self.entry_dv_input = pn.widgets.FloatInput(
+            name="Entry DV", value=round(default_dv, 1), step=10.0,
+            sizing_mode="stretch_width", margin=(5, 2), disabled=True,
+        )
+        self.insertion_depth_input = pn.widgets.FloatInput(
+            name="Insertion depth (µm)", value=4000.0, step=100.0, start=0.0,
+            sizing_mode="stretch_width", margin=(5, 2),
+        )
+        self.snap_surface_button = pn.widgets.Button(
+            name="⤓ Snap to brain surface", button_type="default",
+            width=170, margin=(23, 2, 0, 2),
+        )
+        self.snap_surface_button.on_click(self._on_snap_to_surface)
+        # Grouped for the sync helpers, in (AP, ML, DV) order.
+        self._tip_inputs = (self.tip_ap_input, self.tip_ml_input, self.tip_dv_input)
+        self._entry_inputs = (self.entry_ap_input, self.entry_ml_input, self.entry_dv_input)
         self.pitch_input = pn.widgets.FloatInput(
             name="Pitch (deg)", value=0.0, step=1.0,
             start=-90.0, end=90.0, sizing_mode="stretch_width", margin=(5, 2),
@@ -2443,16 +2694,34 @@ class ChannelmapGUI(param.Parameterized):
         # Once an overlay exists, live-update it (bands + slices) whenever any
         # pose / bregma / squish / tilt input changes, so edits are visible
         # immediately instead of only on the next Compute click.
-        self._anatomy_overlay_active = False
         # atlas_name + bregma toggle do their own batched recompute (via
-        # _on_atlas_change / _on_bregma_toggle), so they're not in this list.
+        # _on_atlas_change / _on_bregma_toggle), so they're not in these lists.
+
+        # Inputs that move the probe: these must mirror the other coordinate
+        # triplet *before* the overlay recomputes, so they go through one
+        # handler rather than also being watched by the recompute directly.
         for _w in (self.tip_ap_input, self.tip_ml_input, self.tip_dv_input,
-                   self.pitch_input, self.yaw_input, self.shank_orientation_input,
+                   self.entry_ap_input, self.entry_ml_input, self.entry_dv_input,
+                   self.insertion_depth_input,
+                   self.pitch_input, self.yaw_input):
+            _w.param.watch(self._on_pose_input_change, "value")
+
+        # Inputs that cannot change the tip↔entry relationship:
+        #   - shank orientation spins *around* the shank axis;
+        #   - the landmark shifts both triplets identically in the display
+        #     frame, so their offset is untouched;
+        #   - squish / tilt are passed as 1.0 / 0.0 by _from_display, i.e.
+        #     they only warp the locator image. If they are ever wired in for
+        #     real, they must move to the list above.
+        for _w in (self.shank_orientation_input,
                    self.bregma_ap_input, self.bregma_ml_input, self.bregma_dv_input,
                    self.dv_squish_input, self.ap_squish_input, self.ml_squish_input,
                    self.tilt_input):
             _w.param.watch(self._recompute_anatomy_if_active, "value")
+
+        self.coord_mode_input.param.watch(self._on_coord_mode_change, "value")
         self._update_landmark_labels()  # name the toggle/fields for the default atlas
+        self._sync_coord_fields()       # seed entry_* from the default tip
         self.anatomy_help = pn.pane.HTML(
             (
                 '<div style="font-size: 11px; color: #555; padding: 2px 0 6px 0; text-align: justify;">'
@@ -2460,6 +2729,18 @@ class ChannelmapGUI(param.Parameterized):
                 "<b>Yaw</b> = ML tilt (probe leaning left / right). "
                 "<b>Shank orientation</b> = direction of shanks 0→3 in the "
                 "horizontal plane; 0° = lateral (+ML), 90° = anterior (+AP)."
+                "<br><br>"
+                "<b>Tip / Insertion</b> picks which coordinates you type; the "
+                "other set is greyed out and follows automatically. It also "
+                "decides what the probe <b>pivots around</b> when you change an "
+                "angle — the tip, or the entry point (usually what you want "
+                "over a fixed craniotomy). <b>Insertion depth</b> is travel "
+                "along the shank from the brain surface to the <i>physical "
+                "shank tip</i>, i.e. what you advance the manipulator by. The "
+                "lowest electrode trails it by this probe's tip length, so "
+                "depths below that leave the electrodes still out of the "
+                "brain. <b>Snap</b> puts the entry point on the brain surface "
+                "— in Tip mode it keeps the tip and sets the depth instead."
                 "</div>"
             ),
             sizing_mode="stretch_width",
@@ -2483,8 +2764,12 @@ class ChannelmapGUI(param.Parameterized):
         )
 
         # Set initial button label based on whether the default atlas is already cached.
+        # Snapping needs the annotation volume, so it stays disabled until the
+        # atlas is on disk rather than kicking off a silent multi-hundred-MB
+        # download from an innocuous-looking button.
         if not anatomy_atlas.is_downloaded(atlas_default):
             self.compute_anatomy_button.name = "Download & compute atlas 🧠 ⏳"
+            self.snap_surface_button.disabled = True
 
         # IMRO file dropper
         self.imro_file_loader = pn.widgets.FileInput(width=300)
@@ -2677,7 +2962,10 @@ class ChannelmapGUI(param.Parameterized):
                 pn.pane.Markdown("## Anatomical overlay 🧠", margin=(-5, 0, 0, 0)),
                 self.atlas_name_input,
                 self.anatomy_coord_note,
+                self.coord_mode_input,
                 pn.Row(self.tip_ap_input, self.tip_ml_input, self.tip_dv_input, sizing_mode="stretch_width"),
+                pn.Row(self.entry_ap_input, self.entry_ml_input, self.entry_dv_input, sizing_mode="stretch_width"),
+                pn.Row(self.insertion_depth_input, self.snap_surface_button, sizing_mode="stretch_width"),
                 pn.Row(self.pitch_input, self.yaw_input, self.shank_orientation_input, sizing_mode="stretch_width"),
                 self.anatomy_help,
                 self.bregma_estimate_header,
@@ -2815,6 +3103,13 @@ class ChannelmapGUI(param.Parameterized):
         # Set reference_id to the first available option if current selection is not available
         if self.reference_id not in self.param.reference_id.objects:
             self.reference_id = self.param.reference_id.objects[0]
+
+        # Insertion depth is referenced to the physical shank tip, so a probe
+        # with a different tip length shifts the tip↔entry relationship.
+        # Guarded because param can fire this before create_widgets() runs.
+        if hasattr(self, "insertion_depth_input"):
+            self._sync_coord_fields()
+            self._recompute_anatomy_if_active()
 
     def update_electrode_counter(self):
         """Update status information"""

--- a/pixelmap/utils/probe_features.py
+++ b/pixelmap/utils/probe_features.py
@@ -21,6 +21,11 @@ PROBE_FEATURES : dict[str, dict]
       vertical_pitch         – electrode vertical pitch (µm)
       layout_geometry        – "staggered", "linear", etc.
       num_shanks             – number of shanks
+      tip_length_um          – distance from the physical shank tip up to the
+                               lowest electrode row (tip_length_um). PixelMap
+                               measures electrode positions from the lowest
+                               electrode, so this is the offset between the
+                               two references.
       pixelmap_probe_type    – PixelMap internal type string, or None if unknown.
 
 PROBE_TYPE_MAP : dict[str, list[str]]
@@ -373,6 +378,7 @@ def _build(source_json_path: Path) -> dict:
             "vertical_pitch":        float(data["electrode_pitch_vert_um"]),
             "layout_geometry":       data["electrode_layout_type"],
             "num_shanks":            n_shanks,
+            "tip_length_um":         float(data["tip_length_um"]),
             "pixelmap_probe_type":   ptype,
         }
     return result

--- a/pixelmap/wiring_maps/pixelmap_probe_features.json
+++ b/pixelmap/wiring_maps/pixelmap_probe_features.json
@@ -11,6 +11,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1001": {
@@ -25,6 +26,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1010": {
@@ -39,6 +41,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1011": {
@@ -53,6 +56,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1012": {
@@ -67,6 +71,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1013": {
@@ -81,6 +86,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1014": {
@@ -95,6 +101,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "NP1015": {
@@ -109,6 +116,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "NHP-short-linear"
   },
   "NP1016": {
@@ -123,6 +131,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "NHP-short-linear"
   },
   "NP1017": {
@@ -137,6 +146,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "NHP-short-linear"
   },
   "NP1020": {
@@ -151,6 +161,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-medium-staggered"
   },
   "NP1021": {
@@ -165,6 +176,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-medium-staggered"
   },
   "NP1022": {
@@ -179,6 +191,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-medium-linear"
   },
   "NP1030": {
@@ -193,6 +206,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-staggered"
   },
   "NP1031": {
@@ -207,6 +221,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-staggered"
   },
   "NP1032": {
@@ -221,6 +236,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1033": {
@@ -235,6 +251,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1040": {
@@ -249,6 +266,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1041": {
@@ -263,6 +281,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1042": {
@@ -277,6 +296,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1050": {
@@ -291,6 +311,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1051": {
@@ -305,6 +326,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 373.0,
     "pixelmap_probe_type": "NHP-long-linear"
   },
   "NP1100": {
@@ -319,6 +341,7 @@
     "vertical_pitch": 6.0,
     "layout_geometry": "8x48",
     "num_shanks": 1,
+    "tip_length_um": 206.5,
     "pixelmap_probe_type": "UHD1"
   },
   "NP1110": {
@@ -333,6 +356,7 @@
     "vertical_pitch": 6.0,
     "layout_geometry": "8x768",
     "num_shanks": 1,
+    "tip_length_um": 203.5,
     "pixelmap_probe_type": "UHD2"
   },
   "NP1120": {
@@ -347,6 +371,7 @@
     "vertical_pitch": 4.5,
     "layout_geometry": "2x192",
     "num_shanks": 1,
+    "tip_length_um": 205.75,
     "pixelmap_probe_type": "UHD3-2x192"
   },
   "NP1121": {
@@ -361,6 +386,7 @@
     "vertical_pitch": 3.0,
     "layout_geometry": "1x384",
     "num_shanks": 1,
+    "tip_length_um": 205.25,
     "pixelmap_probe_type": "UHD3-1x384"
   },
   "NP1122": {
@@ -375,6 +401,7 @@
     "vertical_pitch": 3.0,
     "layout_geometry": "16x24",
     "num_shanks": 1,
+    "tip_length_um": 205.25,
     "pixelmap_probe_type": "UHD3-16x24"
   },
   "NP1123": {
@@ -389,6 +416,7 @@
     "vertical_pitch": 4.5,
     "layout_geometry": "12x32",
     "num_shanks": 1,
+    "tip_length_um": 205.75,
     "pixelmap_probe_type": "UHD3-12x32"
   },
   "NP1200": {
@@ -403,6 +431,7 @@
     "vertical_pitch": 31.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 372.0,
     "pixelmap_probe_type": "NHP-passive"
   },
   "NP1210": {
@@ -417,6 +446,7 @@
     "vertical_pitch": 31.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 372.0,
     "pixelmap_probe_type": "NHP-passive"
   },
   "NP1300": {
@@ -431,6 +461,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "Opto"
   },
   "NP2000": {
@@ -445,6 +476,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "NP2003": {
@@ -459,6 +491,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "NP2004": {
@@ -473,6 +506,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "NP2005": {
@@ -487,6 +521,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "NP2006": {
@@ -501,6 +536,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "NP2010": {
@@ -515,6 +551,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-4shanks"
   },
   "NP2013": {
@@ -529,6 +566,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-4shanks"
   },
   "NP2014": {
@@ -543,6 +581,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-4shanks"
   },
   "NP2020": {
@@ -557,6 +596,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "QuadBase"
   },
   "NP2021": {
@@ -571,6 +611,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "QuadBase"
   },
   "NP3000": {
@@ -585,6 +626,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "1x128",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "NXT-passive"
   },
   "NP3010": {
@@ -599,6 +641,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 203.0,
     "pixelmap_probe_type": "NXT-1shank"
   },
   "NP3011": {
@@ -613,6 +656,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 203.0,
     "pixelmap_probe_type": "NXT-1shank"
   },
   "NP3020": {
@@ -627,6 +671,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 204.0,
     "pixelmap_probe_type": "NXT-4shank"
   },
   "NP3021": {
@@ -641,6 +686,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 204.0,
     "pixelmap_probe_type": "NXT-4shank"
   },
   "NP3022": {
@@ -655,6 +701,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 204.0,
     "pixelmap_probe_type": "NXT-4shank"
   },
   "NP3023": {
@@ -669,6 +716,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 204.0,
     "pixelmap_probe_type": "NXT-4shank"
   },
   "NP3024": {
@@ -683,6 +731,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 204.0,
     "pixelmap_probe_type": "NXT-4shank"
   },
   "PRB2_1_2_0640_0": {
@@ -697,6 +746,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 1,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-1shank"
   },
   "PRB2_4_2_0640_0": {
@@ -711,6 +761,7 @@
     "vertical_pitch": 15.0,
     "layout_geometry": "linear",
     "num_shanks": 4,
+    "tip_length_um": 206.0,
     "pixelmap_probe_type": "2.0-4shanks"
   },
   "PRB_1_2_0480_2": {
@@ -725,6 +776,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "PRB_1_4_0480_1": {
@@ -739,6 +791,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   },
   "PRB_1_4_0480_1_C": {
@@ -753,6 +806,7 @@
     "vertical_pitch": 20.0,
     "layout_geometry": "staggered",
     "num_shanks": 1,
+    "tip_length_um": 209.0,
     "pixelmap_probe_type": "1.0"
   }
 }

--- a/tests/test_anatomy_atlas.py
+++ b/tests/test_anatomy_atlas.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from pixelmap.anatomy.transform import probe_axis
+
 from pixelmap.anatomy import atlas as atlas_module
 from pixelmap.anatomy import regions as regions_module
 
@@ -103,8 +105,13 @@ class TestRegionsForPositions:
         assert regions[1].acronym == "RIGHT"
 
 
-def _atlas_cls(orientation, annotation, structures=None):
-    """Build a fake BrainGlobeAtlas class with a given orientation/annotation."""
+def _atlas_cls(orientation, annotation, structures=None, resolution=(25.0, 25.0, 25.0)):
+    """Build a fake BrainGlobeAtlas class with a given orientation/annotation.
+
+    ``resolution`` is in the atlas's *native* axis order, matching brainglobe.
+    Pass an anisotropic value to catch axis-transposition bugs, which are
+    invisible when every voxel dimension is the same.
+    """
     structures = structures or {
         1: {"acronym": "ONE", "name": "One", "rgb_triplet": [1, 2, 3]},
         2: {"acronym": "TWO", "name": "Two", "rgb_triplet": [4, 5, 6]},
@@ -114,7 +121,7 @@ def _atlas_cls(orientation, annotation, structures=None):
         def __init__(self, name, **_kwargs):
             self.name = name
             self.orientation = orientation
-            self.resolution = (25.0, 25.0, 25.0)
+            self.resolution = resolution
             self.annotation = annotation
             self.structures = structures
 
@@ -185,3 +192,126 @@ class TestOrientation:
         posterior = atlas_module.lookup_regions("x", np.array([[75.0, 0.0, 0.0]]))
         assert anterior[0].acronym == "ONE"
         assert posterior[0].acronym == "TWO"
+
+
+class TestVoxelIndexHelper:
+    """The shared (AP, ML, DV) µm → (ap, dv, ml) index mapping."""
+
+    def test_matches_the_documented_mapping(self):
+        # Anisotropic on purpose: with equal voxel dimensions a swapped DV/ML
+        # axis produces identical numbers and the bug goes unnoticed.
+        voxel_size = np.array([25.0, 10.0, 50.0])   # annotation order (AP, DV, ML)
+        coords = np.array([                          # coordinate order (AP, ML, DV)
+            [100.0, 500.0, 40.0],
+            [75.0, 150.0, 25.0],
+        ])
+        out = atlas_module._voxel_indices(coords, voxel_size)
+        expected = np.array([
+            [round(100.0 / 25.0), round(40.0 / 10.0), round(500.0 / 50.0)],
+            [round(75.0 / 25.0), round(25.0 / 10.0), round(150.0 / 50.0)],
+        ])
+        np.testing.assert_array_equal(out, expected)
+
+    def test_rounds_to_nearest_voxel(self):
+        out = atlas_module._voxel_indices(np.array([[37.0, 0.0, 0.0]]), np.array([25.0] * 3))
+        assert out[0, 0] == 1
+
+
+def _brain_block_atlas(orientation="asr", resolution=(25.0, 25.0, 25.0)):
+    """Fake atlas with a labelled block floating inside empty space.
+
+    Unlike the module-level ``_FakeAtlas`` (solid, no margin) this one has a
+    genuine dorsal surface for the ray-cast to find.
+    """
+    ann = np.zeros((8, 6, 10), dtype=np.int32)      # (AP, DV, ML)
+    ann[1:7, 1:5, 1:9] = 1
+    return _atlas_cls(orientation, ann, resolution=resolution)
+
+
+class TestSurfacePoint:
+    """Locating where a trajectory enters the brain."""
+
+    def test_vertical_trajectory_hits_the_dorsal_surface(self, monkeypatch):
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _brain_block_atlas())
+        out = atlas_module.surface_point_um("x", (100.0, 100.0, 100.0))
+        # First labelled DV voxel is index 1 → 25 µm; AP/ML are unchanged
+        # because an untilted trajectory only moves in DV.
+        assert out is not None
+        assert out[0] == pytest.approx(100.0)
+        assert out[1] == pytest.approx(100.0)
+        assert out[2] == pytest.approx(25.0, abs=25.0)
+        assert out[2] < 100.0, "entry must be dorsal of the starting point"
+
+    def test_result_depends_only_on_the_line(self, monkeypatch):
+        # Casting from the tip and from a point far up the shank — outside
+        # the volume entirely — must agree. This is what lets the GUI's snap
+        # button behave identically in tip-entry and insertion-entry mode.
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _brain_block_atlas())
+        tip = np.array([100.0, 100.0, 100.0])
+        for pitch, yaw in [(0, 0), (30, 25), (-20, 10)]:
+            from_tip = atlas_module.surface_point_um(
+                "x", tuple(tip), pitch_deg=pitch, yaw_deg=yaw)
+            far = tuple(tip + 4000.0 * probe_axis(pitch, yaw))
+            from_far = atlas_module.surface_point_um(
+                "x", far, pitch_deg=pitch, yaw_deg=yaw)
+            assert from_tip is not None and from_far is not None
+            np.testing.assert_allclose(from_tip, from_far, atol=1e-6)
+
+    def test_returns_none_when_the_trajectory_misses_the_brain(self, monkeypatch):
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _brain_block_atlas())
+        assert atlas_module.surface_point_um("x", (100.0, 99999.0, 100.0)) is None
+
+    def test_returns_none_for_unlabelled_volume(self, monkeypatch):
+        empty = _atlas_cls("asr", np.zeros((8, 6, 10), dtype=np.int32))
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", empty)
+        assert atlas_module.surface_point_um("x", (100.0, 100.0, 100.0)) is None
+
+    def test_tilted_trajectory_shifts_ap(self, monkeypatch):
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _brain_block_atlas())
+        straight = atlas_module.surface_point_um("x", (100.0, 100.0, 100.0))
+        tilted = atlas_module.surface_point_um(
+            "x", (100.0, 100.0, 100.0), pitch_deg=45)
+        assert straight is not None and tilted is not None
+        # Positive pitch puts the top of the probe at larger AP, so entering
+        # from above means the entry point is posterior of the anchor.
+        assert tilted[0] > straight[0]
+
+    def test_works_for_non_asr_orientation(self, monkeypatch):
+        # Same brain, described in a flipped native frame: the entry point
+        # must come out the same in canonical coordinates.
+        ann_asr = np.zeros((8, 6, 10), dtype=np.int32)
+        ann_asr[1:7, 1:5, 1:9] = 1
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _atlas_cls("asr", ann_asr))
+        expected = atlas_module.surface_point_um("x", (100.0, 100.0, 100.0))
+
+        atlas_module.get_atlas.cache_clear()
+        atlas_module.canonical_annotation.cache_clear()
+        # "psr" reverses AP, so flip the volume to describe the same brain.
+        monkeypatch.setattr(
+            atlas_module, "BrainGlobeAtlas",
+            _atlas_cls("psr", np.flip(ann_asr, axis=0).copy()))
+        got = atlas_module.surface_point_um("y", (100.0, 100.0, 100.0))
+        assert expected is not None and got is not None
+        np.testing.assert_allclose(got, expected, atol=1e-6)
+
+    def test_thin_dorsal_layer_is_not_stepped_over(self, monkeypatch):
+        # One 25 µm-thick DV layer inside a coarse 100 µm AP grid. A march
+        # step taken from the wrong axis (or from max(resolution)) walks
+        # straight past it and reports the layer below instead.
+        ann = np.zeros((8, 6, 10), dtype=np.int32)
+        ann[1:7, 1, 1:9] = 1          # thin dorsal sheet
+        ann[1:7, 3:5, 1:9] = 2        # bulk, well below it
+        structs = {1: {"acronym": "SKIN", "name": "s", "rgb_triplet": [1, 1, 1]},
+                   2: {"acronym": "BULK", "name": "b", "rgb_triplet": [2, 2, 2]}}
+        monkeypatch.setattr(
+            atlas_module, "BrainGlobeAtlas",
+            _atlas_cls("asr", ann, structs, resolution=(100.0, 25.0, 25.0)))
+        out = atlas_module.surface_point_um("x", (300.0, 100.0, 200.0))
+        assert out is not None
+        region = atlas_module.lookup_regions("x", np.array([list(out)]))[0]
+        assert region is not None and region.acronym == "SKIN"
+
+    def test_rejects_non_positive_step(self, monkeypatch):
+        monkeypatch.setattr(atlas_module, "BrainGlobeAtlas", _brain_block_atlas())
+        with pytest.raises(ValueError):
+            atlas_module.surface_point_um("x", (100.0, 100.0, 100.0), step_um=0.0)

--- a/tests/test_anatomy_transform.py
+++ b/tests/test_anatomy_transform.py
@@ -16,10 +16,22 @@ Conventions (mirror the docstring of :mod:`pixelmap.anatomy.transform`):
 import numpy as np
 import pytest
 
-from pixelmap.anatomy.transform import probe_to_atlas
+from pixelmap.anatomy.transform import (
+    atlas_to_bregma_um,
+    bregma_to_atlas_um,
+    insertion_depth_um,
+    insertion_to_tip,
+    probe_axis,
+    probe_to_atlas,
+    tip_to_insertion,
+)
 
 
 TOL = 1e-6
+
+# Poses spanning both signs and the degenerate ±90° cases.
+POSES = [(p, y) for p in (-45, -20, 0, 20, 45, 90) for y in (-30, 0, 30, 90)]
+SPINS = (-30, 0, 90, 180)
 
 
 class TestVerticalProbe:
@@ -155,3 +167,192 @@ class TestInputValidation:
     def test_list_input_accepted(self):
         out = probe_to_atlas([[0.0, 0.0]], tip_atlas=(1.0, 2.0, 3.0))
         np.testing.assert_allclose(out[0], (1.0, 2.0, 3.0), atol=TOL)
+
+
+class TestProbeAxis:
+    """The along-shank unit vector, shared by probe_to_atlas and the
+    insertion-point conversions."""
+
+    def test_matches_probe_to_atlas_yp_displacement(self):
+        # The load-bearing invariant: moving L µm up the shank must be the
+        # same operation whether you go through probe_to_atlas or probe_axis.
+        # This is what stops the insertion math drifting from the electrode
+        # math, and it re-asserts spin-independence at the same time.
+        tip = np.array([5000.0, 2500.0, 3000.0])
+        L = 1234.5
+        for pitch, yaw in POSES:
+            for spin in SPINS:
+                out = probe_to_atlas([[0.0, L]], tip, pitch, yaw, spin)[0]
+                np.testing.assert_allclose(
+                    out - tip, L * probe_axis(pitch, yaw), atol=1e-9,
+                    err_msg=f"pitch={pitch} yaw={yaw} spin={spin}",
+                )
+
+    def test_closed_form(self):
+        # Pins the derivation even though the implementation is matrix-based.
+        for pitch, yaw in POSES:
+            p, y = np.deg2rad(pitch), np.deg2rad(yaw)
+            expected = (np.sin(p), np.sin(y) * np.cos(p), -np.cos(y) * np.cos(p))
+            np.testing.assert_allclose(probe_axis(pitch, yaw), expected, atol=TOL)
+
+    def test_is_unit_vector(self):
+        for pitch, yaw in POSES:
+            assert abs(np.linalg.norm(probe_axis(pitch, yaw)) - 1.0) < TOL
+
+    def test_vertical_probe_points_dorsally(self):
+        # Up the shank on an untilted probe is -DV (dorsal).
+        np.testing.assert_allclose(probe_axis(0, 0), (0.0, 0.0, -1.0), atol=TOL)
+
+
+class TestInsertionPoint:
+    """Converting between the tip and the point where the shank enters."""
+
+    TIP = (5000.0, 2500.0, 3000.0)
+
+    def test_round_trip(self):
+        for depth in (0.0, 10.0, 4000.0):
+            for pitch, yaw in POSES:
+                entry = tip_to_insertion(self.TIP, depth, pitch, yaw)
+                np.testing.assert_allclose(
+                    insertion_to_tip(entry, depth, pitch, yaw), self.TIP, atol=1e-9,
+                )
+
+    def test_insertion_lies_on_the_shank(self):
+        # The entry point *is* "the point depth µm up the shank", so it must
+        # coincide with the electrode-array math for every shank orientation.
+        for pitch, yaw in POSES:
+            for spin in SPINS:
+                np.testing.assert_allclose(
+                    tip_to_insertion(self.TIP, 3000.0, pitch, yaw),
+                    probe_to_atlas([[0.0, 3000.0]], self.TIP, pitch, yaw, spin)[0],
+                    atol=1e-9,
+                )
+
+    def test_depth_is_along_shank_not_dv(self):
+        # Depth is manipulator travel down the shank, not a vertical drop:
+        # at 60° of pitch a 1000 µm insertion only gains 500 µm of DV.
+        delta = tip_to_insertion(self.TIP, 1000.0, 60, 0) - np.array(self.TIP)
+        assert abs(abs(delta[2]) - 500.0) < 1e-6
+        assert abs(np.linalg.norm(delta) - 1000.0) < 1e-6
+
+    def test_no_singularity_at_ninety_degrees(self):
+        # A horizontal probe is a legal pose; a vertical-depth
+        # parameterisation would divide by cos(90°) here.
+        entry = tip_to_insertion(self.TIP, 1000.0, 90, 0)
+        assert np.all(np.isfinite(entry))
+        np.testing.assert_allclose(
+            insertion_to_tip(entry, 1000.0, 90, 0), self.TIP, atol=1e-9)
+
+    def test_depth_recovers_from_two_points(self):
+        for pitch, yaw in POSES:
+            entry = tip_to_insertion(self.TIP, 2750.0, pitch, yaw)
+            assert abs(insertion_depth_um(self.TIP, entry, pitch, yaw) - 2750.0) < 1e-6
+
+    def test_depth_is_negative_when_tip_is_above_the_entry_point(self):
+        # The probe has not reached that point yet. A norm-based
+        # implementation would wrongly report a healthy positive depth.
+        entry = np.array(self.TIP) + np.array([0.0, 0.0, 500.0])  # deeper than the tip
+        assert insertion_depth_um(self.TIP, entry) == pytest.approx(-500.0)
+
+
+class TestShankTipOffset:
+    """Depth is manipulator travel of the *physical* shank tip, while
+    ``tip_atlas`` is the lowest electrode — ``tip_length_um`` bridges them."""
+
+    TIP = (5000.0, 2500.0, 3000.0)
+    TIP_LEN = 209.0                       # NP 1.0; NP 2.0 is 206 µm
+
+    def test_offset_shortens_the_electrode_reach(self):
+        # Of 4000 µm of travel, the last 209 µm is inactive silicon, so the
+        # lowest electrode only makes it 3791 µm below the surface.
+        entry = tip_to_insertion(self.TIP, 4000.0, 0, 0, self.TIP_LEN)
+        assert np.linalg.norm(entry - np.array(self.TIP)) == pytest.approx(3791.0)
+
+    def test_zero_offset_reproduces_electrode_referenced_depth(self):
+        for pitch, yaw in POSES:
+            np.testing.assert_allclose(
+                tip_to_insertion(self.TIP, 4000.0, pitch, yaw, 0.0),
+                tip_to_insertion(self.TIP, 4000.0, pitch, yaw),
+                atol=1e-9,
+            )
+
+    def test_round_trip_with_offset(self):
+        for depth in (0.0, 209.0, 4000.0):
+            for pitch, yaw in POSES:
+                entry = tip_to_insertion(self.TIP, depth, pitch, yaw, self.TIP_LEN)
+                np.testing.assert_allclose(
+                    insertion_to_tip(entry, depth, pitch, yaw, self.TIP_LEN),
+                    self.TIP, atol=1e-9,
+                )
+
+    def test_depth_recovers_with_offset(self):
+        for pitch, yaw in POSES:
+            entry = tip_to_insertion(self.TIP, 3500.0, pitch, yaw, self.TIP_LEN)
+            got = insertion_depth_um(self.TIP, entry, pitch, yaw, self.TIP_LEN)
+            assert got == pytest.approx(3500.0)
+
+    def test_depth_equal_to_tip_length_puts_electrodes_at_the_surface(self):
+        # Shank tip exactly tip_length deep → the lowest electrode is level
+        # with the brain surface.
+        entry = tip_to_insertion(self.TIP, self.TIP_LEN, 20, -10, self.TIP_LEN)
+        np.testing.assert_allclose(entry, self.TIP, atol=1e-9)
+
+    def test_shallower_than_tip_length_leaves_electrodes_above_the_surface(self):
+        # Physically meaningful, not an error: the tip has entered but the
+        # electrodes have not. The lowest electrode ends up dorsal of the
+        # entry point, i.e. at smaller DV.
+        entry = tip_to_insertion(self.TIP, 100.0, 0, 0, self.TIP_LEN)
+        assert entry[2] > self.TIP[2], "entry should be deeper than the electrode"
+
+    def test_probe_features_supply_a_tip_length_for_every_supported_probe(self):
+        # The GUI reads this per part number; a missing or zero value would
+        # silently fall back to electrode-referenced depth.
+        from pixelmap.constants import PROBE_TYPE_MAP, WIRING_FILE_MAP
+        from pixelmap.utils.probe_features import PROBE_FEATURES
+
+        for probe_type in WIRING_FILE_MAP:
+            for part_number in PROBE_TYPE_MAP[probe_type]:
+                tip_len = PROBE_FEATURES[part_number]["tip_length_um"]
+                assert tip_len > 0, f"{part_number} has no tip length"
+                # Sanity band: every Neuropixels shank tip is ~0.2 mm.
+                assert 150.0 < tip_len < 400.0, f"{part_number}: {tip_len}"
+
+
+class TestBregmaRoundTrip:
+    """atlas_to_bregma_um must exactly invert bregma_to_atlas_um."""
+
+    def test_inverts_forward_transform(self):
+        rng = np.random.default_rng(0)
+        for _ in range(500):
+            coords = tuple(rng.uniform(-6000, 6000, 3))
+            bregma = tuple(rng.uniform(0, 9000, 3))
+            # dv_squish=0 included on purpose: the forward guards it with a
+            # truthiness test, so the inverse has to guard it identically.
+            squish = float(rng.choice([1.0, 0.885, 0.5, 0.0]))
+            tilt = float(rng.uniform(-30, 30))
+            atlas = bregma_to_atlas_um(
+                coords, bregma_um=bregma, dv_squish=squish, tilt_deg=tilt)
+            back = atlas_to_bregma_um(
+                atlas, bregma_um=bregma, dv_squish=squish, tilt_deg=tilt)
+            np.testing.assert_allclose(back, coords, atol=1e-6)
+
+    def test_ap_axis_flips(self):
+        # Bregma-frame +AP is anterior, which is *decreasing* atlas AP.
+        bregma = (5200.0, 5700.0, 440.0)
+        out = atlas_to_bregma_um((4200.0, 5700.0, 440.0), bregma_um=bregma)
+        assert out[0] == pytest.approx(1000.0)
+
+    def test_display_offset_is_independent_of_the_landmark(self):
+        # Why the GUI does not re-mirror when the landmark moves: with
+        # squish/tilt neutral the display transform's linear part is
+        # constant, so the tip→entry offset it shows depends only on the
+        # pose. If real squish/tilt are ever folded in, this breaks — which
+        # is exactly the signal to re-sync on those inputs.
+        tip = np.array([6000.0, 5000.0, 4000.0])
+        entry = tip + 3000.0 * probe_axis(15, -10)
+        offsets = []
+        for bregma in [(5200.0, 5700.0, 440.0), (100.0, 20.0, 7.0)]:
+            t = np.array(atlas_to_bregma_um(tuple(tip), bregma_um=bregma))
+            e = np.array(atlas_to_bregma_um(tuple(entry), bregma_um=bregma))
+            offsets.append(e - t)
+        np.testing.assert_allclose(offsets[0], offsets[1], atol=TOL)


### PR DESCRIPTION
Addresses #42

Adds a **Tip / Insertion** switch to the anatomical overlay so probe coordinates can be entered from the craniotomy instead of from the tip. The inactive triplet is greyed out and live-mirrors the derived value, an insertion-depth field links the two, and a snap button finds where the trajectory actually enters the brain.

## What it does

| | |
|---|---|
| **Tip / Insertion switch** | Pick which triplet you type. The other stays visible and updates live, so both ends of the trajectory are always readable. |
| **Insertion depth** | Travel along the shank — the manipulator reading — so it stays correct at any tilt. Editable in both modes. |
| **Pivot follows the mode** | Changing an angle holds whichever coordinate you are entering fixed. In insertion mode the probe pivots about the entry point, as it does over a real craniotomy. |
| **⤓ Snap to brain surface** | In insertion mode, places the entry point on the surface. In tip mode, holds the tip and reports the depth you would need. Disabled until the atlas is downloaded. |

## Worth a careful look

**Two different "tips".** Insertion depth is referenced to the *physical shank tip*, because that is what a manipulator reads. `tip_atlas` everywhere else is the *lowest electrode*. The offset comes from `tip_length_um` in Bill Karsh's probe JSON (209 µm on 1.0, 206 µm on 2.0/QuadBase) — not hardcoded — and is re-applied when the part number changes. This is the one design decision I would most like a second opinion on; it is flagged in the issue.

A consequence, which is intended: a depth below the tip length correctly shows the shank tip in the brain with the electrodes still above the surface.

**The overlay path is untouched.** Because the tip fields are always kept in sync, `_tip_atlas_um()` is unchanged and `compute_anatomy_overlay` / `compute_region_bands` / `render_locator` never learn about the new mode. `test_anatomy_schematic.py` and `test_anatomy_visualization.py` pass unmodified, which is the check that this held.

**Watcher wiring in `gui.py`** is the fragile part. Widgets that move the probe are funnelled through `_on_pose_input_change`, which mirrors *before* recomputing. Watching them with `_recompute_anatomy_if_active` as well would render the overlay against a stale tip and then render it again — two 300-dpi `savefig` calls per keystroke. `_syncing_coords` guards the mirrored write, since `disabled` is front-end only and those writes still fire watchers. The mode switch deliberately does not re-sync, which is what keeps repeated toggling bit-stable.

**`surface_point_um` clips the ray to the volume bounding box** rather than marching a fixed window around the anchor. The insertion point is routinely *outside* the volume, so a fixed window is not guaranteed to reach the brain — and the answer would then depend on which point of the line you passed in, making the snap button behave differently in the two modes. `test_result_depends_only_on_the_line` pins this.

**Small shared refactor:** the `(AP, ML, DV) µm → (ap, dv, ml)` index math is extracted to `_voxel_indices()` and now shared with `lookup_regions`. The existing `lookup_regions` tests cover the change, plus a new one using an anisotropic voxel size — equal voxel dimensions hide a transposition bug.

## Testing

`150 passed` (120 pre-existing, unmodified, + 30 new).

New coverage lives in `tests/test_anatomy_transform.py` and `tests/test_anatomy_atlas.py`, no atlas download needed. The load-bearing one is `test_matches_probe_to_atlas_yp_displacement`: it asserts that moving *L* µm up the shank is the same operation via `probe_axis` as via `probe_to_atlas`, across a grid of pitch/yaw/spin. That is what stops the insertion math drifting from the electrode math.

I sanity-checked the new tests by mutation — breaking the march step, the DV/ML transposition, the march direction, the `dv_squish` guard and the AP sign flip each produced a specific failure.

The GUI wiring itself (one render per edit, no drift across repeated mode toggles, cleared-field safety, snap gating) was verified with a throwaway harness rather than a committed test, since the repo has no GUI tests and starting that felt like a separate decision. Happy to add one if you would like it.


